### PR TITLE
Add show command, identify current selection

### DIFF
--- a/internal/chooser/chooser.go
+++ b/internal/chooser/chooser.go
@@ -1,6 +1,8 @@
 package chooser
 
 import (
+	"strings"
+
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -23,7 +25,7 @@ func (c *Chooser) Choice() (string, bool) {
 		return "", false
 	}
 
-	return c.choice, true
+	return strings.TrimSuffix(c.choice, " *"), true
 }
 
 // ...

--- a/internal/chooser/chooser_test.go
+++ b/internal/chooser/chooser_test.go
@@ -1,0 +1,11 @@
+package chooser_test
+
+import (
+	"testing"
+)
+
+func Test_New(_ *testing.T) {}
+
+func Test_Chooser_View(_ *testing.T) {}
+
+func Test_Chooser_Choice(_ *testing.T) {}

--- a/internal/chooser/delegate.go
+++ b/internal/chooser/delegate.go
@@ -44,12 +44,12 @@ func (*delegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd {
 //
 //nolint:gocritic // (hugeParam) required interface defined elsewhere
 func (*delegate) Render(writer io.Writer, model list.Model, index int, item list.Item) {
-	i, ok := item.(fmt.Stringer)
+	i, ok := item.(interface{ Value() string })
 	if !ok {
 		return
 	}
 
-	str := fmt.Sprintf("%d. %s", index+1, i.String())
+	str := i.Value()
 
 	fn := itemStyle.Render
 	if index == model.Index() {

--- a/internal/chooser/item.go
+++ b/internal/chooser/item.go
@@ -1,6 +1,9 @@
 package chooser
 
 import (
+	"cmp"
+	"slices"
+
 	"github.com/charmbracelet/bubbles/list"
 )
 
@@ -21,12 +24,28 @@ func newItems(values []string, current string) []list.Item {
 		})
 	}
 
+	//nolint:forcetypeassert // no risk of other types being here
+	slices.SortFunc(items, func(a, b list.Item) int {
+		return cmp.Compare(a.(item).value, b.(item).value)
+	})
+
 	return items
 }
 
 // ...
 func (i item) String() string {
 	return i.value
+}
+
+// ...
+func (i item) Value() string {
+	v := i.String()
+
+	if i.current {
+		return v + " *"
+	}
+
+	return v
 }
 
 // ...

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -6,9 +6,16 @@ import (
 
 // ...
 type CLI struct {
+	Show      Show      `cmd:"" aliases:"sh" help:"Show current values."`
 	Switch    Switch    `cmd:"" aliases:"sw" default:"1" help:"Switch all values."`
 	Context   Context   `cmd:"" aliases:"ctx" help:"Switch the context only."`
 	Namespace Namespace `cmd:"" aliases:"ns" help:"Switch the namespace only."`
 
 	Version kong.VersionFlag `short:"V" help:"Display the version."`
+}
+
+// Common contains common options for CLI subcommands.
+type Common struct {
+	Config  string `short:"k" name:"kubeconfig" env:"KUBECONFIG" default:"${kubeconfig}" help:"The kubeconfig file to use (env: ${env})."`
+	Verbose int    `short:"v" type:"counter" help:"Increase the log verbosity."`
 }

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -14,16 +14,26 @@ import (
 	"github.com/mattdowdell/kubeswitch/internal/logging"
 )
 
-// ...
+// Context provides the ability to switch the current context within a kube config file.
 type Context struct {
-	Config  string `short:"k" name:"kubeconfig" env:"KUBECONFIG" default:"${kubeconfig}" help:"The kubeconfig file to use (env: ${env})."`
+	Common
+
 	Context string `arg:"" optional:"" help:"The context to switch to."`
-	Verbose int    `short:"v" type:"counter" help:"Increase the log verbosity."`
 }
 
-// ...
+// Help outputs the extended help for the command.
 func (*Context) Help() string {
-	return ""
+	return `A new context can either be selected interactively from the available choices, or using
+a pre-selected value.
+
+Examples:
+	# Pre-select a context
+	kubeswitch ctx CONTEXT
+	kubeswitch context CONTEXT
+
+	# Interactively select a context
+	kubeswitch ctx
+	kubeswitch context`
 }
 
 // ...

--- a/internal/cli/namespace.go
+++ b/internal/cli/namespace.go
@@ -16,16 +16,30 @@ import (
 	"github.com/mattdowdell/kubeswitch/internal/logging"
 )
 
-// ...
+// Namespace provides the ability to switch the namespace for the current context within a kube
+// config file.
 type Namespace struct {
-	Config    string `short:"k" name:"kubeconfig" env:"KUBECONFIG" default:"${kubeconfig}" help:"The kubeconfig file to use (env: ${env})."`
+	Common
+
 	Namespace string `arg:"" optional:""  help:"The namespace to switch to."`
-	Verbose   int    `short:"v" type:"counter" help:"Increase the log verbosity."`
 }
 
-// ...
+// Help outputs the extended help for the command.
 func (*Namespace) Help() string {
-	return ""
+	return `A new namespace can either be selected interactively from the available choices, or
+using a pre-selected value.
+
+This command lists namespaces from the Kubernetes API for interactive selection and validation. As a
+result, a valid kubeconfig with access to namespaces is required.
+
+Examples:
+	# Pre-select the namespace
+	kubeswitch ns NAMESPACE
+	kubeswitch namespace NAMESPACE
+
+	# Interactively select the namespace
+	kubeswitch ns
+	kubeswitch namespace`
 }
 
 // ...

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/mattdowdell/kubeswitch/internal/kube"
+)
+
+// Show outputs the current context and namespace within a kubeconfig file.
+type Show struct {
+	Common
+}
+
+// Help outputs the extended help for the command.
+func (*Show) Help() string {
+	return ""
+}
+
+// ...
+func (s *Show) Run() error {
+	access := kube.NewAccess(s.Config)
+
+	conf, err := access.GetStartingConfig()
+	if err != nil {
+		return err
+	}
+
+	var ns string
+	if ctx, ok := conf.Contexts[conf.CurrentContext]; ok {
+		ns = ctx.Namespace
+	}
+
+	fmt.Println("Context:  ", conf.CurrentContext)
+	fmt.Println("Namespace:", ns)
+
+	return nil
+}

--- a/internal/cli/switch.go
+++ b/internal/cli/switch.go
@@ -7,17 +7,35 @@ import (
 	"github.com/mattdowdell/kubeswitch/internal/logging"
 )
 
-// ...
+// Switch provides the ability to switch the current context and namespace within a kube config
+// file.
 type Switch struct {
-	Config    string `short:"k" name:"kubeconfig" env:"KUBECONFIG" default:"${kubeconfig}" help:"The kubeconfig file to use (env: ${env})."`
+	Common
+
 	Context   string `short:"c" help:"The context to switch to."`
 	Namespace string `short:"n" help:"The namespace to switch to."`
-	Verbose   int    `short:"v" type:"counter" help:"Increase the log verbosity."`
 }
 
-// ...
+// Help outputs the extended help for the command.
 func (*Switch) Help() string {
-	return ""
+	return `A new context and namespace can either be selected interactively from the available
+choices, or using pre-selected values.
+
+This command lists namespaces from the Kubernetes API for interactive selection and validation. As a
+result, a valid kubeconfig with access to namespaces is required.
+
+Examples:
+	# Pre-select all values
+	kubeswitch sw -c CONTEXT -n NAMESPACE
+	kubeswitch switch --context CONTEXT --namespace NAMESPACE
+
+	# Interactively select all values
+	kubeswitch sw
+	kubeswitch switch
+
+	# Mixture of pre-selected and interactive selected values
+	kubeswitch switch --context CONTEXT
+	kubeswitch switch --namespace NAMESPACE`
 }
 
 // ...

--- a/main.go
+++ b/main.go
@@ -12,6 +12,10 @@ import (
 	"github.com/mattdowdell/kubeswitch/internal/version"
 )
 
+const (
+	helpMaxWidth = 100
+)
+
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
@@ -23,6 +27,9 @@ func main() {
 			"kubeconfig": clientcmd.RecommendedHomeFile,
 			"version":    version.Must().String(),
 		},
+		kong.ConfigureHelp(kong.HelpOptions{
+			WrapUpperBound: helpMaxWidth,
+		}),
 		kong.BindTo(ctx, (*context.Context)(nil)),
 	)
 


### PR DESCRIPTION
- Add a `show` subcommand to print the current context and namespace.
- - Remove numbers when selecting a context or namespace.
- Add a `*` suffix when selecting a context or namespace to denote the current selection.
- Populate extended help for the `switch`, `context` and `namespace` subcommands.
- Move common CLI options to a struct embedded into subcommands.
- Limit help output to 100 columns.