### PR TITLE
Make show the default subcommand

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -27,14 +27,7 @@ fmt: fmt-go fmt-just
 # Run the Go formatter.
 [group('formatters')]
 fmt-go:
-    gofumpt -l -w .
-    gci write \
-        --skip-vendor \
-        --skip-generated \
-        -s standard \
-        -s default \
-        -s localmodule \
-        .
+    golangci-lint fmt
 
 # Run the Justfile formatter.
 [group('formatters')]

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ Kubeswitch can be installed via `go install`:
 go install github.com/mattdowdell/kubeswitch@latest
 ```
 
+<!--
 Pre-built binaries for various OS/arch combinations can be downloaded from
 [Releases].
 
 [releases]: https://github.com/mattdowdell/kubeswitch/releases
+-->
 
 ## Usage
 
@@ -22,8 +24,12 @@ kubeconfig file, e.g. `~/.kube/config.yaml`, while namespace are queried from
 the Kubernetes API using the selected context.
 
 ```sh
-# interactively select a context and namespace
+# print current context and namespace
 kubeswitch
+kubeswitch sh
+kubeswitch show
+
+# interactively select a context and namespace
 kubeswitch sw
 kubeswitch switch
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -6,8 +6,8 @@ import (
 
 // ...
 type CLI struct {
-	Show      Show      `cmd:"" aliases:"sh" help:"Show current values."`
-	Switch    Switch    `cmd:"" aliases:"sw" default:"1" help:"Switch all values."`
+	Show      Show      `cmd:"" aliases:"sh" default:"1" help:"Show current values."`
+	Switch    Switch    `cmd:"" aliases:"sw"  help:"Switch all values."`
 	Context   Context   `cmd:"" aliases:"ctx" help:"Switch the context only."`
 	Namespace Namespace `cmd:"" aliases:"ns" help:"Switch the namespace only."`
 


### PR DESCRIPTION
Make `sh/show` the default subcommand as getting the current config seems more common that changing it from my own usage.